### PR TITLE
✨ fix(cmd): remove unnecessary line breaks in code files

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"smart-commit/config"
 	"smart-commit/pkg/generator"
 	"smart-commit/pkg/llm"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,14 +3,13 @@ package cmd
 import (
 	"fmt"
 	"os"
+
 	"smart-commit/config"
 
 	"github.com/spf13/cobra"
 )
 
-var (
-	configFile string
-)
+var configFile string
 
 var rootCmd = &cobra.Command{
 	Use:   "smart-commit",

--- a/main.go
+++ b/main.go
@@ -5,4 +5,3 @@ import "smart-commit/cmd"
 func main() {
 	cmd.Execute()
 }
-

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -2,6 +2,7 @@ package generator
 
 import (
 	"fmt"
+
 	"smart-commit/pkg/git"
 	"smart-commit/pkg/llm"
 )


### PR DESCRIPTION
This commit cleans up the code by removing unnecessary line breaks in several Go files, improving readability and maintaining code style consistency.