### PR TITLE
🛠️ fix(config): update default model to use environment variable

### DIFF
--- a/config/loader.go
+++ b/config/loader.go
@@ -27,7 +27,7 @@ func Load(configFile string) (*Config, error) {
 	v.SetEnvPrefix("AICOMMIT")
 	v.AutomaticEnv()
 
-	v.SetDefault("model", "gpt-4o-mini")
+	v.SetDefault("model", v.GetString("model"))
 	v.SetDefault("temperature", 0.3)
 
 	err := autoBindEnv(v, Config{})


### PR DESCRIPTION
Updated the default model setting to retrieve the value from the environment variable instead of a hardcoded string.