### PR TITLE
✨ feat(config): add support for max tokens in OpenAI client configuration

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -21,7 +21,7 @@ and generates a suitable commit message using an AI language model.`,
 		cfg := config.Get()
 
 		g := generator.New(llm.NewOpenAIClient(
-			cfg.OpenAIKey, cfg.Model, cfg.CustomPrompt, cfg.BasePrompt,
+			cfg.OpenAIKey, cfg.Model, cfg.CustomPrompt, cfg.BasePrompt, cfg.MaxTokens,
 		))
 		msg, err := g.Generate()
 		if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,6 +26,7 @@ intelligent commit messages based on the changes in your git repository.`,
 		fmt.Fprintln(os.Stderr, "Configuration loaded successfully.")
 		fmt.Fprintf(os.Stderr, "Using model: %s\n", cfg.Model)
 		fmt.Fprintf(os.Stderr, "Temperature set to: %.2f\n", cfg.Temperature)
+		fmt.Fprintf(os.Stderr, "Max Tokens set to: %d\n", *cfg.MaxTokens)
 		fmt.Fprintln(os.Stderr, "-----------------------------------")
 	},
 }

--- a/config/config.go
+++ b/config/config.go
@@ -8,6 +8,7 @@ type Config struct {
 	Temperature  float32 `mapstructure:"temperature"`
 	CustomPrompt string  `mapstructure:"custom_prompt"`
 	BasePrompt   string  `mapstructure:"base_prompt"`
+	MaxTokens    *int    `mapstructure:"max_tokens"`
 }
 
 // configValue holds the current configuration atomically.

--- a/config/loader.go
+++ b/config/loader.go
@@ -29,6 +29,7 @@ func Load(configFile string) (*Config, error) {
 
 	v.SetDefault("model", "gpt-4o-mini")
 	v.SetDefault("temperature", 0.3)
+	v.SetDefault("max_tokens", 1024)
 
 	err := autoBindEnv(v, Config{})
 	if err != nil {

--- a/pkg/llm/openai.go
+++ b/pkg/llm/openai.go
@@ -13,6 +13,7 @@ type OpenAIClient struct {
 	model        string
 	customPrompt string
 	basePrompt   string
+	maxTokens    *int
 }
 
 func NewOpenAIClient(
@@ -20,12 +21,14 @@ func NewOpenAIClient(
 	model string,
 	customPrompt string,
 	basePrompt string,
+	maxTokens *int,
 ) *OpenAIClient {
 	return &OpenAIClient{
 		apiKey:       apiKey,
 		model:        model,
 		customPrompt: customPrompt,
 		basePrompt:   basePrompt,
+		maxTokens:    maxTokens,
 	}
 }
 
@@ -45,6 +48,7 @@ func (c *OpenAIClient) GenerateCommitMessage(diff string) (string, error) {
 		"messages": []map[string]string{
 			{"role": "user", "content": fmt.Sprintf(prompt, diff)},
 		},
+		"max_tokens": c.maxTokens,
 	}
 
 	body, _ := json.Marshal(req)


### PR DESCRIPTION
Introduced a new configurable option for max tokens, enhancing the AI model's message generation capabilities. Adjusted relevant files to accommodate this feature.