### PR TITLE
🔧 fix(cmd): update import paths to use the new repository structure

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -3,10 +3,9 @@ package cmd
 import (
 	"fmt"
 
-	"smart-commit/config"
-	"smart-commit/pkg/generator"
-	"smart-commit/pkg/llm"
-
+	"github.com/kevinliao852/smart-commit/config"
+	"github.com/kevinliao852/smart-commit/pkg/generator"
+	"github.com/kevinliao852/smart-commit/pkg/llm"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,8 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"smart-commit/config"
-
+	"github.com/kevinliao852/smart-commit/config"
 	"github.com/spf13/cobra"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module smart-commit
+module github.com/kevinliao852/smart-commit
 
 go 1.24.2
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "smart-commit/cmd"
+import "github.com/kevinliao852/smart-commit/cmd"
 
 func main() {
 	cmd.Execute()

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -3,8 +3,8 @@ package generator
 import (
 	"fmt"
 
-	"smart-commit/pkg/git"
-	"smart-commit/pkg/llm"
+	"github.com/kevinliao852/smart-commit/pkg/git"
+	"github.com/kevinliao852/smart-commit/pkg/llm"
 )
 
 type Generator struct {


### PR DESCRIPTION
Updated import paths in cmd and pkg directories to reflect the new GitHub repository structure for better organization and maintainability.