### PR TITLE
🎉 chore(goreleaser): rename build target for better clarity

### DIFF
--- a/goreleaser.yaml
+++ b/goreleaser.yaml
@@ -5,7 +5,7 @@ before:
     - go mod tidy
 
 builds:
-  - id: build-linux
+  - id: smart-commit
     ldflags:
       - -s -w
       - "-extldflags '-static'"
@@ -51,7 +51,7 @@ release:
 
 upx:
   - enabled: true
-    ids: [build-linux]
+    ids: [smart-commit]
     goos: [linux, darwin]
     goarch: [arm, amd64]
     compress: best


### PR DESCRIPTION
Updated the build target ID in the goreleaser.yaml configuration file to "smart-commit" for enhanced clarity and maintainability.