### PR TITLE
✅ ci(release): enable fetching of tags in the workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
+          fetch-tags: true
       - name: Set up Go
         uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:


### PR DESCRIPTION
Updated the GitHub Actions workflow to include fetching of tags, ensuring that all relevant tags are available for the release process.