### PR TITLE
🚀 Add command to show configuration file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ smart-commit generate
 
 The generated message will be displayed, and you will be prompted to confirm or edit it before committing.
 
+To see the location of the configuration file being used:
+
+```bash
+smart-commit where
+```
+
 ## Configuration
 
 The configuration file is typically located at `~/.config/smart-commit/config.yaml`.

--- a/cmd/where.go
+++ b/cmd/where.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/kevinliao852/smart-commit/config"
+	"github.com/spf13/cobra"
+)
+
+var whereCmd = &cobra.Command{
+	Use:   "where",
+	Short: "Show the configuration file path",
+	Long:  `Show the path of the configuration file being used by smart-commit.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		cfg := config.Get()
+		if cfg == nil || cfg.ConfigPath == "" {
+			fmt.Println("No configuration file found.")
+			return
+		}
+		fmt.Println(cfg.ConfigPath)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(whereCmd)
+}

--- a/config/config.go
+++ b/config/config.go
@@ -9,6 +9,7 @@ type Config struct {
 	CustomPrompt string  `mapstructure:"custom_prompt"`
 	BasePrompt   string  `mapstructure:"base_prompt"`
 	MaxTokens    *int    `mapstructure:"max_tokens"`
+	ConfigPath   string  `mapstructure:"-"`
 }
 
 // configValue holds the current configuration atomically.

--- a/config/loader.go
+++ b/config/loader.go
@@ -44,6 +44,7 @@ func Load(configFile string) (*Config, error) {
 	if err := v.Unmarshal(&cfg); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
 	}
+	cfg.ConfigPath = v.ConfigFileUsed()
 
 	store(&cfg)
 


### PR DESCRIPTION
This commit introduces a new command, `where`, which displays the path of the configuration file currently in use by the smart-commit tool. The command is implemented in `cmd/where.go`, making it easy for users to locate their configuration file. Additionally, the `Config` struct in `config/config.go` has been updated to include a `ConfigPath` field, which stores the path of the configuration file. The `Load` function in `loader.go` has also been modified to populate this new field. This enhancement improves usability by allowing users to quickly access their configuration file path through a simple command.